### PR TITLE
bugfix: '\' file separator is only supported by windows (dir() fails …

### DIFF
--- a/+agora_connector/+models/DownloadDatasetMixin.m
+++ b/+agora_connector/+models/DownloadDatasetMixin.m
@@ -8,6 +8,7 @@ classdef (Abstract, HandleCompatible) DownloadDatasetMixin
             addOptional(p,'keep_zip_files', false, booleanValidator);
             addOptional(p,'progress', false, booleanValidator);
             addOptional(p,'max_size_to_zip', 20, @isnumeric);
+            addOptional(p,'subfolder',true, booleanValidator);
             parse(p, varargin{:});
             options = p.Results;
            
@@ -34,7 +35,11 @@ classdef (Abstract, HandleCompatible) DownloadDatasetMixin
                 for i = 1:length(direct)
                     % download directly
                     df = direct(i).to_datafile();
-                    final_path = fullfile(path, direct(i).rel_path);
+                    if options.subfolder
+                        final_path = fullfile(path, direct(i).rel_path);
+                    else
+                        final_path = fullfile(path);
+                    end
                     if options.progress
                         disp(['downloading ', fullfile(final_path, df.original_filename), '...']);
                     end

--- a/+agora_connector/+models/ImportPackage.m
+++ b/+agora_connector/+models/ImportPackage.m
@@ -440,7 +440,7 @@ classdef ImportPackage < agora_connector.models.BaseModel
                 path = paths{i};
                 if isfolder(path)
                     root = path;
-                    filelist = dir(fullfile(path, '**\*.*'));
+                    filelist = dir(fullfile(path, '**/*.*'));
                     for j = 1:length(filelist)
                         if ~filelist(j).isdir
                             absolute_file_path = fullfile(filelist(j).folder, filelist(j).name);


### PR DESCRIPTION
…on UNIX/MAC), use universal '/' instead